### PR TITLE
Fixed enum `required` logic

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
@@ -16,7 +16,7 @@ internal class MainCommand : ApplicationCommand
     public string? Test { get; set; } = null;
 
     [CommandOption('l', "log-level", Description = "Level of logs to show.")]
-    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    public required LogLevel LogLevel { get; set; } = LogLevel.Information;
 
     public override bool ExitOnRunComplete => false;
 

--- a/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
+++ b/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "ApplicationBuilderHelpers.Test.Cli": {
-      "commandName": "Project",
-      "commandLineArgs": "-h"
+      "commandName": "Project"
     }
   }
 }

--- a/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
+++ b/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "ApplicationBuilderHelpers.Test.Cli": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "-l debUG"
     }
   }
 }


### PR DESCRIPTION
#### PR Classification
Enhancement of command-line argument handling and validation.

#### PR Summary
This pull request updates the command-line interface to enforce required properties and improve validation for options and arguments. Key changes include:
- `MainCommand.cs`: The `LogLevel` property is now required.
- `launchSettings.json`: Command line arguments updated to `-l debUG`.
- `ApplicationBuilder.cs`: `CreateOption` and `CreateArgument` methods modified to accept a `required` parameter.
- `ApplicationBuilder.cs`: Enhanced validation logic for enum arguments to check for required values.
- `ApplicationBuilder.cs`: Updated `GetEnumValidation` method to include a `required` parameter for better enforcement of enum requirements.
