### PR TITLE
Refactor application command structure for flexibility

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -35,7 +35,7 @@ public class ApplicationBuilder
 
         public CommandLineBuilder CommandLineBuilder { get; set; } = commandLineBuilder;
 
-        public ApplicationCommand? AppCommand { get; set; } = null;
+        public IApplicationCommand? AppCommand { get; set; } = null;
 
         public Dictionary<string, ApplicationCommandHierarchy> SubCommands { get; set; } = [];
     }
@@ -50,7 +50,7 @@ public class ApplicationBuilder
     }
 
     private readonly List<ApplicationDependency> _applicationDependencies = [];
-    private readonly List<ApplicationCommand> _commands = [];
+    private readonly List<IApplicationCommand> _commands = [];
     private readonly Dictionary<Type, ICommandLineTypeParser> _typeParsers = new()
     {
         [typeof(AbsolutePath)] = new AbsolutePathTypeParser(),
@@ -94,7 +94,7 @@ public class ApplicationBuilder
     /// <param name="applicationCommand">The application command instance.</param>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
     public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TApplicationCommand>(TApplicationCommand applicationCommand)
-        where TApplicationCommand : ApplicationCommand
+        where TApplicationCommand : IApplicationCommand
     {
         _commands.Add(applicationCommand);
         return this;
@@ -106,7 +106,7 @@ public class ApplicationBuilder
     /// <typeparam name="TApplicationCommand">The type of the application command.</typeparam>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
     public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TApplicationCommand>()
-        where TApplicationCommand : ApplicationCommand
+        where TApplicationCommand : IApplicationCommand
     {
         return AddCommand(applicationCommand: Activator.CreateInstance<TApplicationCommand>());
     }
@@ -199,7 +199,7 @@ public class ApplicationBuilder
         return await rootHierarchy.CommandLineBuilder.Build().InvokeAsync(args);
     }
 
-    private void WireHandler(ApplicationCommandHierarchy hier, ApplicationCommand applicationCommand, CancellationToken stoppingToken)
+    private void WireHandler(ApplicationCommandHierarchy hier, IApplicationCommand applicationCommand, CancellationToken stoppingToken)
     {
         PropertyInfo[] properties = applicationCommand.GetType().GetProperties();
 
@@ -366,13 +366,13 @@ public class ApplicationBuilder
                 var applicationBuilder = await applicationCommand.ApplicationBuilderInternal(cts.Token);
                 foreach (var dependency in _applicationDependencies)
                 {
-                    applicationBuilder.AddApplication(dependency);
+                    applicationBuilder.ApplicationDependencies.Add(dependency);
                 }
-                applicationBuilder.AddApplication(applicationCommand);
+                applicationBuilder.ApplicationDependencies.Add(applicationCommand);
                 CommandInvokerService commandInvokerService = new();
                 applicationBuilder.Services.AddSingleton(commandInvokerService);
                 applicationBuilder.Services.AddHostedService<CommandInvokerWorker>();
-                var applicationHost = applicationBuilder.Build();
+                var applicationHost = applicationBuilder.BuildInternal();
                 commandInvokerService.SetCommand(async ct =>
                 {
                     await applicationCommand.RunInternal(applicationHost, ct);

--- a/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
+++ b/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
@@ -42,4 +42,8 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Folder Include="Extensions\" />
+	</ItemGroup>
+
 </Project>

--- a/ApplicationBuilderHelpers/ApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/ApplicationCommand.cs
@@ -11,7 +11,7 @@ using ApplicationBuilderHelpers.Interfaces;
 namespace ApplicationBuilderHelpers;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public abstract class ApplicationCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : ApplicationDependency
+public abstract class ApplicationCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : ApplicationDependency, IApplicationCommand
     where THostApplicationBuilder : IHostApplicationBuilder
 {
     /// <summary>
@@ -51,26 +51,6 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
     public virtual bool ExitOnRunComplete { get; } = true;
 
     /// <summary>
-    /// Builds the application builder internally.
-    /// </summary>
-    /// <param name="stoppingToken">A token to cancel the operation.</param>
-    /// <returns>An instance of <see cref="ApplicationHostBuilder{THostApplicationBuilder}"/>.</returns>
-    internal async ValueTask<ApplicationHostBuilder<THostApplicationBuilder>> ApplicationBuilderInternal(CancellationToken stoppingToken)
-    {
-        var hostApplicationBuilder = await ApplicationBuilder(stoppingToken);
-        return new ApplicationHostBuilder<THostApplicationBuilder>(hostApplicationBuilder);
-    }
-
-    /// <summary>
-    /// Runs the application internally.
-    /// </summary>
-    /// <param name="applicationHost">The application host.</param>
-    /// <param name="stoppingToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    internal ValueTask RunInternal(ApplicationHost<THostApplicationBuilder> applicationHost, CancellationToken stoppingToken)
-        => Run(applicationHost, stoppingToken);
-
-    /// <summary>
     /// Builds the application builder.
     /// </summary>
     /// <param name="stoppingToken">A token to cancel the operation.</param>
@@ -86,6 +66,19 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
     protected virtual ValueTask Run(ApplicationHost<THostApplicationBuilder> applicationHost, CancellationToken stoppingToken)
     {
         return new ValueTask();
+    }
+
+    /// <inheritdoc/>
+    async ValueTask<ApplicationHostBuilder> IApplicationCommand.ApplicationBuilderInternal(CancellationToken stoppingToken)
+    {
+        var hostApplicationBuilder = await ApplicationBuilder(stoppingToken);
+        return new ApplicationHostBuilder<THostApplicationBuilder>(hostApplicationBuilder);
+    }
+
+    /// <inheritdoc/>
+    ValueTask IApplicationCommand.RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken)
+    {
+        return Run((applicationHost as ApplicationHost<THostApplicationBuilder>)!, stoppingToken);
     }
 }
 

--- a/ApplicationBuilderHelpers/ApplicationHost.cs
+++ b/ApplicationBuilderHelpers/ApplicationHost.cs
@@ -15,7 +15,7 @@ namespace ApplicationBuilderHelpers;
 /// <summary>
 /// Represents a builder for managing application dependencies and running the configured application.
 /// </summary>
-public abstract class ApplicationHost(IHostApplicationBuilder builder, IHost host) : ApplicationHostBuilder(builder)
+public abstract class ApplicationHost(IHostApplicationBuilder builder, IHost host) : ApplicationHostBuilderBase(builder)
 {
     /// <summary>
     /// Gets the <see cref="IHost"/> created from <see cref="ApplicationDependencyBuilderHost{THostApplicationBuilder}.Build"/>.

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ApplicationBuilderHelpers.Interfaces;
+
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+public interface IApplicationCommand : IApplicationDependency
+{
+    /// <summary>
+    /// Gets the name of the command.
+    /// </summary>
+    string? Name { get; }
+
+    /// <summary>
+    /// Gets the description of the command.
+    /// </summary>
+    string? Description { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the application should exit after the <see cref="Run(ApplicationHost{THostApplicationBuilder}, CancellationToken)"/> method is complete.
+    /// </summary>
+    bool ExitOnRunComplete { get; }
+
+    /// <summary>
+    /// Builds the application builder internally.
+    /// </summary>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>An instance of <see cref="ApplicationHostBuilder{THostApplicationBuilder}"/>.</returns>
+    internal ValueTask<ApplicationHostBuilder> ApplicationBuilderInternal(CancellationToken stoppingToken);
+
+    /// <summary>
+    /// Runs the application internally.
+    /// </summary>
+    /// <param name="applicationHost">The application host.</param>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal ValueTask RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken);
+}


### PR DESCRIPTION
#### PR Classification
This pull request implements an interface-based design for application commands to enhance abstraction and flexibility.

#### PR Summary
The changes refactor the command handling system to utilize an interface, improving the structure and management of application commands. 
- `ApplicationBuilder.cs`: Changed `ApplicationCommand?` to `IApplicationCommand?` and updated `_commands` to `List<IApplicationCommand>`.
- `ApplicationBuilder.cs`: Modified `AddCommand` method to use `IApplicationCommand` as a constraint.
- `ApplicationBuilder.cs`: Updated `WireHandler` method to accept `IApplicationCommand`.
- `IApplicationCommand.cs`: Introduced a new interface defining essential properties and methods for application commands.
- `ApplicationHostBuilder.cs`: Renamed to `ApplicationHostBuilderBase` and added an internal `BuildInternal` method for better building process management.
