### PR TITLE
Enhance MainCommand with new properties and validation

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
@@ -23,8 +23,8 @@ internal class MainCommand : ApplicationCommand
     [CommandOption("test-paths", Description = "Test args paths")]
     public required AbsolutePath[] TestPaths { get; set; }
 
-    [CommandOption('l', "log-level", Description = "Level of logs to show.")]
-    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    [CommandOption('l', "log-level", Description = "Level of logs to show.", FromAmong = ["Trace", "Debug", "Information", "Warning", "Error", "Critical"])]
+    public string LogLevel { get; set; } = "Information";
 
     public override bool ExitOnRunComplete => false;
 

--- a/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
+++ b/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ApplicationBuilderHelpers.Test.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "--test-path \".\" --test-paths \"./awd\" --test-paths \"./cdcd\"",
+      "commandLineArgs": "-l debugg --test-path \".\" --test-paths \"./awd\" --test-paths \"./cdcd\"",
       "environmentVariables": {
         "ENV_TEST1": "TestVal1"
       }

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -263,6 +263,10 @@ public class ApplicationBuilder
             {
                 option.SetDefaultValue(currentValueObj);
             }
+            if (attribute.FromAmong.Length != 0)
+            {
+                option.FromAmong([.. attribute.FromAmong.Select(i => i?.ToString() ?? "").Where(i => !string.IsNullOrEmpty(i))]);
+            }
             valueResolver.Add(context =>
             {
                 object? value = null;


### PR DESCRIPTION
Enhance MainCommand with new properties and validation

- Added `TestPaths` property to `MainCommand` for multiple paths.
- Changed `LogLevel` type from `LogLevel` enum to `string` with `FromAmong` attribute for better flexibility.
- Updated `launchSettings.json` to include new log level argument in command line.
- Implemented validation for command line options in `ApplicationBuilder` to restrict values based on `FromAmong`.