### PR TITLE
Refactor MainCommand and improve validation logic

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
@@ -23,8 +23,8 @@ internal class MainCommand : ApplicationCommand
     [CommandOption("test-paths", Description = "Test args paths")]
     public required AbsolutePath[] TestPaths { get; set; }
 
-    [CommandOption('l', "log-level", Description = "Level of logs to show.", FromAmong = ["Trace", "Debug", "Information", "Warning", "Error", "Critical"])]
-    public string LogLevel { get; set; } = "Information";
+    [CommandOption('l', "log-level", Description = "Level of logs to show.")]
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
     public override bool ExitOnRunComplete => false;
 

--- a/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
+++ b/ApplicationBuilderHelpers.Test.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ApplicationBuilderHelpers.Test.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "-l debugg --test-path \".\" --test-paths \"./awd\" --test-paths \"./cdcd\"",
+      "commandLineArgs": "-l debUg --test-path \".\" --test-paths \"./awd\" --test-paths \"./cdcd\"",
       "environmentVariables": {
         "ENV_TEST1": "TestVal1"
       }


### PR DESCRIPTION
Refactor MainCommand and improve validation logic

Updated LogLevel property to use enum type and added TestPaths array in MainCommand. Modified launchSettings.json to correct log level casing. Enhanced validation in ApplicationBuilder to utilize FromAmong as an array for more flexible option checks.