### PR TITLE
Add command preparation methods and documentation

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
@@ -65,4 +65,9 @@ internal class MainCommand : ApplicationCommand
         Console.WriteLine("Hello from main AddServicesAddServicesAddServicesAddServicesAddServicesAddServices");
         base.AddServices(applicationBuilder, services);
     }
+
+    protected override ValueTask CommanPreparation(CancellationToken stoppingToken)
+    {
+        return base.CommanPreparation(stoppingToken);
+    }
 }

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -195,6 +195,7 @@ public class ApplicationBuilder
                 }
             }
             currentHier.AppCommand = command;
+            await command.CommanPreparationInternal(cancellationTokenSource.Token);
             WireHandler(rootHierarchy, currentHier, currentHier.AppCommand, cancellationTokenSource.Token);
         }
 

--- a/ApplicationBuilderHelpers/ApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/ApplicationCommand.cs
@@ -58,6 +58,16 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
     protected abstract ValueTask<THostApplicationBuilder> ApplicationBuilder(CancellationToken stoppingToken);
 
     /// <summary>
+    /// Prepares the command for execution.
+    /// </summary>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>A completed <see cref="ValueTask"/>.</returns>
+    protected virtual ValueTask CommanPreparation(CancellationToken stoppingToken)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
     /// Runs the application.
     /// </summary>
     /// <param name="applicationHost">The application host.</param>
@@ -66,6 +76,11 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
     protected virtual ValueTask Run(ApplicationHost<THostApplicationBuilder> applicationHost, CancellationToken stoppingToken)
     {
         return new ValueTask();
+    }
+
+    ValueTask IApplicationCommand.CommanPreparationInternal(CancellationToken stoppingToken)
+    {
+        return CommanPreparation(stoppingToken);
     }
 
     /// <inheritdoc/>

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
@@ -10,6 +10,9 @@ using System.Threading.Tasks;
 
 namespace ApplicationBuilderHelpers.Interfaces;
 
+/// <summary>
+/// Represents a command that can be executed within the application.
+/// </summary>
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 public interface IApplicationCommand : IApplicationDependency
 {
@@ -27,6 +30,13 @@ public interface IApplicationCommand : IApplicationDependency
     /// Gets a value indicating whether the application should exit after the <see cref="Run(ApplicationHost{THostApplicationBuilder}, CancellationToken)"/> method is complete.
     /// </summary>
     bool ExitOnRunComplete { get; }
+
+    /// <summary>
+    /// Prepares the command for execution internally.
+    /// </summary>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal ValueTask CommanPreparationInternal(CancellationToken stoppingToken);
 
     /// <summary>
     /// Builds the application builder internally.


### PR DESCRIPTION
Add command preparation methods and documentation

- Introduced `CommanPreparation` method in `MainCommand` for command execution preparation.
- Added asynchronous call to `CommanPreparationInternal` in `ApplicationBuilder` to ensure command readiness.
- Updated `ApplicationCommand` with a new virtual `CommanPreparation` method providing a default implementation.
- Enhanced `IApplicationCommand` interface with an internal `CommanPreparationInternal` method for internal command preparation.
- Added XML documentation to new methods for improved code clarity and maintainability.