### PR TITLE
Refactor CommandException class constructors

### DIFF
--- a/ApplicationBuilderHelpers/Exceptions/CommandException.cs
+++ b/ApplicationBuilderHelpers/Exceptions/CommandException.cs
@@ -6,7 +6,19 @@ using System.Threading.Tasks;
 
 namespace ApplicationBuilderHelpers.Exceptions;
 
-public class CommandException(string message, int exitCode) : Exception(message)
+public class CommandException : Exception
 {
-    public int ExitCode { get; } = exitCode;
+    public int ExitCode { get; }
+
+    public CommandException(int exitCode)
+        : base(null)
+    {
+        ExitCode = exitCode;
+    }
+
+    public CommandException(string message, int exitCode)
+        : base(message)
+    {
+        ExitCode = exitCode;
+    }
 }


### PR DESCRIPTION
#### PR Classification
Refactor of the `CommandException` class to improve constructor flexibility.

#### PR Summary
The `CommandException` class has been refactored to provide two distinct constructors for better usability. This change enhances the initialization of the `ExitCode` property and allows for instantiation without a message.
- `CommandException.cs`: Split the constructor into two; one for `exitCode` and another for `message` and `exitCode`. Initialized `ExitCode` within the constructors.
