### PR TITLE
Add version handling and utility for version strings

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -2,6 +2,7 @@
 using ApplicationBuilderHelpers.Attributes;
 using ApplicationBuilderHelpers.Common;
 using ApplicationBuilderHelpers.Exceptions;
+using ApplicationBuilderHelpers.Extensions;
 using ApplicationBuilderHelpers.Interfaces;
 using ApplicationBuilderHelpers.ParserTypes;
 using ApplicationBuilderHelpers.ParserTypes.Enumerables;
@@ -151,11 +152,20 @@ public class ApplicationBuilder
 
     /// <summary>
     /// Runs the application asynchronously.
-    /// </summary>
+    /// </summary> 
     /// <param name="args">The command-line arguments.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the exit code of the application.</returns>
     public async Task<int> RunAsync(string[] args)
     {
+        if (args.Length == 1 && args.First().Equals("--version", StringComparison.InvariantCultureIgnoreCase))
+        {
+            var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+            var assemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? "0.0.0";
+            Console.WriteLine(VersionHelpers.RemoveHash(assemblyInformationalVersion));
+            return 0;
+        }
+
         CancellationTokenSource cancellationTokenSource = new();
         Console.CancelKeyPress += (sender, e) =>
         {

--- a/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
+++ b/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
@@ -42,8 +42,4 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Extensions\" />
-	</ItemGroup>
-
 </Project>

--- a/ApplicationBuilderHelpers/Extensions/VersionHelpers.cs
+++ b/ApplicationBuilderHelpers/Extensions/VersionHelpers.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationBuilderHelpers.Extensions;     
+
+internal static class VersionHelpers
+{
+    internal static string RemoveHash(string version)
+    {
+        int plusIndex = version.IndexOf('+');
+        if (plusIndex == -1)
+            return version; // No build metadata
+
+        string baseVersion = version[..plusIndex];
+        string metadata = version[(plusIndex + 1)..];
+
+        string[] parts = metadata.Split('.');
+
+        // Check if the last part is a hex hash (length 40 or 64, all hex chars)
+        string last = parts.Last();
+        if (IsHex(last) && (last.Length == 40 || last.Length == 64))
+        {
+            parts = [.. parts.Take(parts.Length - 1)];
+        }
+
+        return parts.Length > 0 ? $"{baseVersion}+{string.Join(".", parts)}" : baseVersion;
+    }
+
+    static bool IsHex(string s)
+    {
+        foreach (char c in s)
+        {
+            if (!((c >= '0' && c <= '9') ||
+                  (c >= 'a' && c <= 'f') ||
+                  (c >= 'A' && c <= 'F')))
+                return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature implementation for command-line version display and version string processing.

#### PR Summary
This pull request introduces a command-line argument for displaying the application version and adds functionality to process version strings by removing build metadata. 
- `ApplicationBuilder.cs`: Added handling for `--version` argument in `RunAsync` method and included a new using directive for `ApplicationBuilderHelpers.Extensions`.
- `VersionHelpers.cs`: Introduced a new static class with a method to remove hex hash metadata from version strings.
- `ApplicationBuilderHelpers.csproj`: Removed folder reference for `Extensions`, simplifying the project structure.
