### PR TITLE
Fix method naming and enhance command preparation logic

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Commands/MainCommand.cs
@@ -69,8 +69,8 @@ internal class MainCommand : BaseCommand
         base.AddServices(applicationBuilder, services);
     }
 
-    protected override ValueTask CommanPreparation(CancellationToken stoppingToken)
+    protected override ValueTask CommandPreparation(CancellationToken stoppingToken)
     {
-        return base.CommanPreparation(stoppingToken);
+        return base.CommandPreparation(stoppingToken);
     }
 }

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -205,7 +205,11 @@ public class ApplicationBuilder
                 }
             }
             currentHier.AppCommand = command;
-            await command.CommanPreparationInternal(cancellationTokenSource.Token);
+            foreach (var dependency in _applicationDependencies)
+            {
+                dependency.CommandPreparation(command);
+            }
+            await command.CommandPreparationInternal(cancellationTokenSource.Token);
             WireHandler(rootHierarchy, currentHier, currentHier.AppCommand, cancellationTokenSource.Token);
         }
 

--- a/ApplicationBuilderHelpers/ApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/ApplicationCommand.cs
@@ -62,7 +62,7 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
     /// </summary>
     /// <param name="stoppingToken">A token to cancel the operation.</param>
     /// <returns>A completed <see cref="ValueTask"/>.</returns>
-    protected virtual ValueTask CommanPreparation(CancellationToken stoppingToken)
+    protected virtual ValueTask CommandPreparation(CancellationToken stoppingToken)
     {
         return ValueTask.CompletedTask;
     }
@@ -78,9 +78,9 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
         return new ValueTask();
     }
 
-    ValueTask IApplicationCommand.CommanPreparationInternal(CancellationToken stoppingToken)
+    ValueTask IApplicationCommand.CommandPreparationInternal(CancellationToken stoppingToken)
     {
-        return CommanPreparation(stoppingToken);
+        return CommandPreparation(stoppingToken);
     }
 
     /// <inheritdoc/>

--- a/ApplicationBuilderHelpers/ApplicationDependency.cs
+++ b/ApplicationBuilderHelpers/ApplicationDependency.cs
@@ -2,12 +2,18 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Threading;
 
 namespace ApplicationBuilderHelpers;
 
 /// <inheritdoc/>
 public abstract class ApplicationDependency : IApplicationDependency
 {
+    /// <inheritdoc/>
+    public virtual void CommandPreparation(IApplicationCommand applicationCommand)
+    {
+    }
+
     /// <inheritdoc/>
     public virtual void BuilderPreparation(ApplicationHostBuilder applicationBuilder)
     {

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
@@ -36,7 +36,7 @@ public interface IApplicationCommand : IApplicationDependency
     /// </summary>
     /// <param name="stoppingToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    internal ValueTask CommanPreparationInternal(CancellationToken stoppingToken);
+    internal ValueTask CommandPreparationInternal(CancellationToken stoppingToken);
 
     /// <summary>
     /// Builds the application builder internally.

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationDependency.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationDependency.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ApplicationBuilderHelpers.Interfaces;
 
@@ -9,6 +11,12 @@ namespace ApplicationBuilderHelpers.Interfaces;
 /// </summary>
 public interface IApplicationDependency
 {
+    /// <summary>
+    /// Prepares the application command before the application starts.
+    /// </summary>
+    /// <param name="applicationCommand">The application command to prepare.</param>
+    void CommandPreparation(IApplicationCommand applicationCommand);
+
     /// <summary>
     /// Invoked first during the application setup, allowing the application builder to be prepared before any other configuration methods are called.
     /// </summary>


### PR DESCRIPTION
#### PR Classification
Code cleanup and method renaming.

#### PR Summary
This pull request corrects the method name `CommanPreparation` to `CommandPreparation` across multiple files for consistency and clarity. It also enhances the command preparation process by introducing new methods and updating interfaces.
- `MainCommand.cs`: Renamed `CommanPreparation` to `CommandPreparation`.
- `ApplicationBuilder.cs`: Replaced `CommanPreparationInternal` with a loop to invoke `CommandPreparation` on dependencies.
- `ApplicationDependency.cs`: Added a new virtual method `CommandPreparation` for custom preparation logic.
- `IApplicationDependency.cs`: Updated to include the new `CommandPreparation` method.
- `IApplicationCommand.cs`: Introduced `CommandPreparationInternal` for internal command preparation.
