### PR TITLE
Refactor command handling interfaces and ApplicationBuilder

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -38,7 +38,7 @@ public class ApplicationBuilder
 
         public CommandLineBuilder CommandLineBuilder { get; set; } = commandLineBuilder;
 
-        public IApplicationCommand? AppCommand { get; set; } = null;
+        public IApplicationCommandDependency? AppCommand { get; set; } = null;
 
         public Dictionary<string, ApplicationCommandHierarchy> SubCommands { get; set; } = [];
     }
@@ -53,7 +53,7 @@ public class ApplicationBuilder
     }
 
     private readonly List<ApplicationDependency> _applicationDependencies = [];
-    private readonly List<IApplicationCommand> _commands = [];
+    private readonly List<IApplicationCommandDependency> _commands = [];
     private readonly Dictionary<Type, ICommandLineTypeParser> _typeParsers = new()
     {
         [typeof(AbsolutePath)] = new AbsolutePathTypeParser(),
@@ -97,7 +97,7 @@ public class ApplicationBuilder
     /// <param name="applicationCommand">The application command instance.</param>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
     public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TApplicationCommand>(TApplicationCommand applicationCommand)
-        where TApplicationCommand : IApplicationCommand
+        where TApplicationCommand : IApplicationCommandDependency
     {
         _commands.Add(applicationCommand);
         return this;
@@ -109,7 +109,7 @@ public class ApplicationBuilder
     /// <typeparam name="TApplicationCommand">The type of the application command.</typeparam>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
     public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TApplicationCommand>()
-        where TApplicationCommand : IApplicationCommand
+        where TApplicationCommand : IApplicationCommandDependency
     {
         return AddCommand(applicationCommand: Activator.CreateInstance<TApplicationCommand>());
     }
@@ -216,7 +216,7 @@ public class ApplicationBuilder
         return await rootHierarchy.CommandLineBuilder.Build().InvokeAsync(args);
     }
 
-    private void WireHandler(ApplicationCommandHierarchy rootHierarchy, ApplicationCommandHierarchy hier, IApplicationCommand applicationCommand, CancellationToken stoppingToken)
+    private void WireHandler(ApplicationCommandHierarchy rootHierarchy, ApplicationCommandHierarchy hier, IApplicationCommandDependency applicationCommand, CancellationToken stoppingToken)
     {
         var properties = new List<PropertyInfo>();
         var currentType = applicationCommand.GetType();

--- a/ApplicationBuilderHelpers/ApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/ApplicationCommand.cs
@@ -11,7 +11,7 @@ using ApplicationBuilderHelpers.Interfaces;
 namespace ApplicationBuilderHelpers;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public abstract class ApplicationCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : ApplicationDependency, IApplicationCommand
+public abstract class ApplicationCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : ApplicationDependency, IApplicationCommandDependency
     where THostApplicationBuilder : IHostApplicationBuilder
 {
     /// <summary>
@@ -78,20 +78,20 @@ public abstract class ApplicationCommand<[DynamicallyAccessedMembers(Dynamically
         return new ValueTask();
     }
 
-    ValueTask IApplicationCommand.CommandPreparationInternal(CancellationToken stoppingToken)
+    ValueTask IApplicationCommandDependency.CommandPreparationInternal(CancellationToken stoppingToken)
     {
         return CommandPreparation(stoppingToken);
     }
 
     /// <inheritdoc/>
-    async ValueTask<ApplicationHostBuilder> IApplicationCommand.ApplicationBuilderInternal(CancellationToken stoppingToken)
+    async ValueTask<ApplicationHostBuilder> IApplicationCommandDependency.ApplicationBuilderInternal(CancellationToken stoppingToken)
     {
         var hostApplicationBuilder = await ApplicationBuilder(stoppingToken);
         return new ApplicationHostBuilder<THostApplicationBuilder>(hostApplicationBuilder);
     }
 
     /// <inheritdoc/>
-    ValueTask IApplicationCommand.RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken)
+    ValueTask IApplicationCommandDependency.RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken)
     {
         return Run((applicationHost as ApplicationHost<THostApplicationBuilder>)!, stoppingToken);
     }

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationCommand.cs
@@ -14,7 +14,7 @@ namespace ApplicationBuilderHelpers.Interfaces;
 /// Represents a command that can be executed within the application.
 /// </summary>
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public interface IApplicationCommand : IApplicationDependency
+public interface IApplicationCommand
 {
     /// <summary>
     /// Gets the name of the command.
@@ -30,26 +30,4 @@ public interface IApplicationCommand : IApplicationDependency
     /// Gets a value indicating whether the application should exit after the <see cref="Run(ApplicationHost{THostApplicationBuilder}, CancellationToken)"/> method is complete.
     /// </summary>
     bool ExitOnRunComplete { get; }
-
-    /// <summary>
-    /// Prepares the command for execution internally.
-    /// </summary>
-    /// <param name="stoppingToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    internal ValueTask CommandPreparationInternal(CancellationToken stoppingToken);
-
-    /// <summary>
-    /// Builds the application builder internally.
-    /// </summary>
-    /// <param name="stoppingToken">A token to cancel the operation.</param>
-    /// <returns>An instance of <see cref="ApplicationHostBuilder{THostApplicationBuilder}"/>.</returns>
-    internal ValueTask<ApplicationHostBuilder> ApplicationBuilderInternal(CancellationToken stoppingToken);
-
-    /// <summary>
-    /// Runs the application internally.
-    /// </summary>
-    /// <param name="applicationHost">The application host.</param>
-    /// <param name="stoppingToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    internal ValueTask RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken);
 }

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationCommandDependency.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationCommandDependency.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ApplicationBuilderHelpers.Interfaces;
+
+/// <summary>
+/// Represents a command that can be executed within the application.
+/// </summary>
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+public interface IApplicationCommandDependency : IApplicationCommand, IApplicationDependency
+{
+    /// <summary>
+    /// Prepares the command for execution internally.
+    /// </summary>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal ValueTask CommandPreparationInternal(CancellationToken stoppingToken);
+
+    /// <summary>
+    /// Builds the application builder internally.
+    /// </summary>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>An instance of <see cref="ApplicationHostBuilder{THostApplicationBuilder}"/>.</returns>
+    internal ValueTask<ApplicationHostBuilder> ApplicationBuilderInternal(CancellationToken stoppingToken);
+
+    /// <summary>
+    /// Runs the application internally.
+    /// </summary>
+    /// <param name="applicationHost">The application host.</param>
+    /// <param name="stoppingToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal ValueTask RunInternal(ApplicationHost applicationHost, CancellationToken stoppingToken);
+}


### PR DESCRIPTION
#### PR Classification
Refactor to improve command and dependency management in the application architecture.

#### PR Summary
This pull request introduces a new interface, `IApplicationCommandDependency`, to separate command properties from execution logic, enhancing the overall architecture. Key changes include:
- **IApplicationCommand.cs**: Removed internal methods from `IApplicationCommand` and created `IApplicationCommandDependency` with those methods.
- **ApplicationBuilder.cs**: Updated `AppCommand` and `_commands` to use `IApplicationCommandDependency` instead of `IApplicationCommand`.
- **ApplicationBuilder.cs**: Modified `AddCommand` methods to accept `IApplicationCommandDependency`.
- **ApplicationBuilder.cs**: Changed `WireHandler` method to work with `IApplicationCommandDependency`.
