### PR TITLE
Refactor of the command line type parsing system

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -54,7 +54,7 @@ public class ApplicationBuilder
 
     private readonly List<ApplicationDependency> _applicationDependencies = [];
     private readonly List<IApplicationCommand> _commands = [];
-    private readonly Dictionary<Type, ICommandLineTypeParser> _typeParsers = new()
+    private readonly Dictionary<Type, ICommandArgsTypeParser> _typeParsers = new()
     {
         [typeof(AbsolutePath)] = new AbsolutePathTypeParser(),
         [typeof(bool)] = new BoolTypeParser(),
@@ -138,14 +138,14 @@ public class ApplicationBuilder
     }
 
     /// <summary>
-    /// Adds a command line type parser to the application.
+    /// Adds a command args type parser to the application.
     /// </summary>
-    /// <typeparam name="TCommandLineTypeParser">The type of the command line type parser.</typeparam>
+    /// <typeparam name="TCommandArgsTypeParser">The type of the command line type parser.</typeparam>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
-    public ApplicationBuilder AddCommandLineType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommandLineTypeParser>()
-        where TCommandLineTypeParser : ICommandLineTypeParser
+    public ApplicationBuilder AddCommandArgsTypeParser<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommandArgsTypeParser>()
+        where TCommandArgsTypeParser : ICommandArgsTypeParser
     {
-        TCommandLineTypeParser commandLineTypeParser = Activator.CreateInstance<TCommandLineTypeParser>();
+        TCommandArgsTypeParser commandLineTypeParser = Activator.CreateInstance<TCommandArgsTypeParser>();
         _typeParsers[commandLineTypeParser.Type] = commandLineTypeParser;
         return this;
     }
@@ -472,7 +472,7 @@ public class ApplicationBuilder
         });
     }
 
-    private static ValidateSymbolResult<TSymbolResult> GetValidation<TSymbolResult>(ICommandLineTypeParser typeParser, string? environmentVariable, bool caseSensitive, bool required, string[] fromAmong)
+    private static ValidateSymbolResult<TSymbolResult> GetValidation<TSymbolResult>(ICommandArgsTypeParser typeParser, string? environmentVariable, bool caseSensitive, bool required, string[] fromAmong)
         where TSymbolResult : SymbolResult
     {
         return a =>

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -54,7 +54,7 @@ public class ApplicationBuilder
 
     private readonly List<ApplicationDependency> _applicationDependencies = [];
     private readonly List<IApplicationCommand> _commands = [];
-    private readonly Dictionary<Type, ICommandArgsTypeParser> _typeParsers = new()
+    private readonly Dictionary<Type, ICommandTypeParser> _typeParsers = new()
     {
         [typeof(AbsolutePath)] = new AbsolutePathTypeParser(),
         [typeof(bool)] = new BoolTypeParser(),
@@ -140,12 +140,12 @@ public class ApplicationBuilder
     /// <summary>
     /// Adds a command args type parser to the application.
     /// </summary>
-    /// <typeparam name="TCommandArgsTypeParser">The type of the command line type parser.</typeparam>
+    /// <typeparam name="TCommandTypeParser">The type of the command line type parser.</typeparam>
     /// <returns>The current instance of the <see cref="ApplicationBuilder"/> class.</returns>
-    public ApplicationBuilder AddCommandArgsTypeParser<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommandArgsTypeParser>()
-        where TCommandArgsTypeParser : ICommandArgsTypeParser
+    public ApplicationBuilder AddCommandTypeParser<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommandTypeParser>()
+        where TCommandTypeParser : ICommandTypeParser
     {
-        TCommandArgsTypeParser commandLineTypeParser = Activator.CreateInstance<TCommandArgsTypeParser>();
+        TCommandTypeParser commandLineTypeParser = Activator.CreateInstance<TCommandTypeParser>();
         _typeParsers[commandLineTypeParser.Type] = commandLineTypeParser;
         return this;
     }
@@ -472,7 +472,7 @@ public class ApplicationBuilder
         });
     }
 
-    private static ValidateSymbolResult<TSymbolResult> GetValidation<TSymbolResult>(ICommandArgsTypeParser typeParser, string? environmentVariable, bool caseSensitive, bool required, string[] fromAmong)
+    private static ValidateSymbolResult<TSymbolResult> GetValidation<TSymbolResult>(ICommandTypeParser typeParser, string? environmentVariable, bool caseSensitive, bool required, string[] fromAmong)
         where TSymbolResult : SymbolResult
     {
         return a =>

--- a/ApplicationBuilderHelpers/Common/TypeExtensions.cs
+++ b/ApplicationBuilderHelpers/Common/TypeExtensions.cs
@@ -13,9 +13,9 @@ namespace ApplicationBuilderHelpers.Common;
 
 internal static class TypeExtensions
 {
-    public static bool TryGetParser(this Type type, Dictionary<Type, ICommandLineTypeParser> typeParsers, bool caseSensitive, bool autoEnumerableType, [NotNullWhen(true)] out ICommandLineTypeParser? commandLineTypeParser)
+    public static bool TryGetParser(this Type type, Dictionary<Type, ICommandArgsTypeParser> typeParsers, bool caseSensitive, bool autoEnumerableType, [NotNullWhen(true)] out ICommandArgsTypeParser? commandLineTypeParser)
     {
-        if (typeParsers.TryGetValue(type, out ICommandLineTypeParser? typeParser))
+        if (typeParsers.TryGetValue(type, out ICommandArgsTypeParser? typeParser))
         {
             commandLineTypeParser = typeParser;
             return true;
@@ -30,7 +30,7 @@ internal static class TypeExtensions
         {
             if (type.IsArray)
             {
-                if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, caseSensitive, true, out ICommandLineTypeParser? itemTypeParser))
+                if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, caseSensitive, true, out ICommandArgsTypeParser? itemTypeParser))
                 {
                     commandLineTypeParser = new ArrayTypeParser(elementType, itemTypeParser);
                     return true;
@@ -57,7 +57,7 @@ internal static class TypeExtensions
         return false;
     }
 
-    public static bool IsEnumerable(this Type type, Dictionary<Type, ICommandLineTypeParser> typeParsers)
+    public static bool IsEnumerable(this Type type, Dictionary<Type, ICommandArgsTypeParser> typeParsers)
     {
         if (typeParsers.TryGetValue(type, out _))
         {
@@ -70,7 +70,7 @@ internal static class TypeExtensions
 
         if (type.IsArray)
         {
-            if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, true, true, out ICommandLineTypeParser? itemTypeParser))
+            if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, true, true, out ICommandArgsTypeParser? itemTypeParser))
             {
                 return true;
             }

--- a/ApplicationBuilderHelpers/Common/TypeExtensions.cs
+++ b/ApplicationBuilderHelpers/Common/TypeExtensions.cs
@@ -13,9 +13,9 @@ namespace ApplicationBuilderHelpers.Common;
 
 internal static class TypeExtensions
 {
-    public static bool TryGetParser(this Type type, Dictionary<Type, ICommandArgsTypeParser> typeParsers, bool caseSensitive, bool autoEnumerableType, [NotNullWhen(true)] out ICommandArgsTypeParser? commandLineTypeParser)
+    public static bool TryGetParser(this Type type, Dictionary<Type, ICommandTypeParser> typeParsers, bool caseSensitive, bool autoEnumerableType, [NotNullWhen(true)] out ICommandTypeParser? commandLineTypeParser)
     {
-        if (typeParsers.TryGetValue(type, out ICommandArgsTypeParser? typeParser))
+        if (typeParsers.TryGetValue(type, out ICommandTypeParser? typeParser))
         {
             commandLineTypeParser = typeParser;
             return true;
@@ -30,7 +30,7 @@ internal static class TypeExtensions
         {
             if (type.IsArray)
             {
-                if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, caseSensitive, true, out ICommandArgsTypeParser? itemTypeParser))
+                if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, caseSensitive, true, out ICommandTypeParser? itemTypeParser))
                 {
                     commandLineTypeParser = new ArrayTypeParser(elementType, itemTypeParser);
                     return true;
@@ -57,7 +57,7 @@ internal static class TypeExtensions
         return false;
     }
 
-    public static bool IsEnumerable(this Type type, Dictionary<Type, ICommandArgsTypeParser> typeParsers)
+    public static bool IsEnumerable(this Type type, Dictionary<Type, ICommandTypeParser> typeParsers)
     {
         if (typeParsers.TryGetValue(type, out _))
         {
@@ -70,7 +70,7 @@ internal static class TypeExtensions
 
         if (type.IsArray)
         {
-            if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, true, true, out ICommandArgsTypeParser? itemTypeParser))
+            if (type.GetElementType() is Type elementType && TryGetParser(elementType, typeParsers, true, true, out ICommandTypeParser? itemTypeParser))
             {
                 return true;
             }

--- a/ApplicationBuilderHelpers/Interfaces/ICommandArgsTypeParser.cs
+++ b/ApplicationBuilderHelpers/Interfaces/ICommandArgsTypeParser.cs
@@ -6,10 +6,10 @@ using System.Text;
 namespace ApplicationBuilderHelpers.Interfaces;
 
 /// <summary>
-/// Interface for parsing command line arguments to a specific type.
+/// Interface for parsing command arguments to a specific type.
 /// </summary>
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public interface ICommandLineTypeParser
+public interface ICommandArgsTypeParser
 {
     /// <summary>
     /// Gets the type that this parser handles.

--- a/ApplicationBuilderHelpers/Interfaces/ICommandTypeParser.cs
+++ b/ApplicationBuilderHelpers/Interfaces/ICommandTypeParser.cs
@@ -6,10 +6,10 @@ using System.Text;
 namespace ApplicationBuilderHelpers.Interfaces;
 
 /// <summary>
-/// Interface for parsing command arguments to a specific type.
+/// Interface for parsing command type to a specific type.
 /// </summary>
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public interface ICommandArgsTypeParser
+public interface ICommandTypeParser
 {
     /// <summary>
     /// Gets the type that this parser handles.

--- a/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
@@ -5,7 +5,7 @@ using AbsolutePathHelpers;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class AbsolutePathTypeParser : ICommandLineTypeParser
+public class AbsolutePathTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(AbsolutePath);
 

--- a/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
@@ -5,7 +5,7 @@ using AbsolutePathHelpers;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class AbsolutePathTypeParser : ICommandArgsTypeParser
+public class AbsolutePathTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(AbsolutePath);
 

--- a/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class BoolTypeParser : ICommandArgsTypeParser
+public class BoolTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(bool);
 

--- a/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class BoolTypeParser : ICommandLineTypeParser
+public class BoolTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(bool);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ByteTypeParser : ICommandLineTypeParser
+public class ByteTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(byte);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ByteTypeParser : ICommandArgsTypeParser
+public class ByteTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(byte);
 

--- a/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class CharTypeParser : ICommandArgsTypeParser
+public class CharTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(char);
 

--- a/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class CharTypeParser : ICommandLineTypeParser
+public class CharTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(char);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DateTimeOffsetTypeParser : ICommandLineTypeParser
+public class DateTimeOffsetTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(DateTimeOffset);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DateTimeOffsetTypeParser : ICommandArgsTypeParser
+public class DateTimeOffsetTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(DateTimeOffset);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DateTimeTypeParser : ICommandLineTypeParser
+public class DateTimeTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(DateTime);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DateTimeTypeParser : ICommandArgsTypeParser
+public class DateTimeTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(DateTime);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DecimalTypeParser : ICommandLineTypeParser
+public class DecimalTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(decimal);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DecimalTypeParser : ICommandArgsTypeParser
+public class DecimalTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(decimal);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DoubleTypeParser : ICommandLineTypeParser
+public class DoubleTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(double);
 

--- a/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class DoubleTypeParser : ICommandArgsTypeParser
+public class DoubleTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(double);
 

--- a/ApplicationBuilderHelpers/ParserTypes/EnumTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/EnumTypeParser.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace ApplicationBuilderHelpers.ParserTypes;
 
 [method: UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
-public class EnumTypeParser(Type enumType, bool caseSensitive) : ICommandLineTypeParser
+public class EnumTypeParser(Type enumType, bool caseSensitive) : ICommandArgsTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/EnumTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/EnumTypeParser.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace ApplicationBuilderHelpers.ParserTypes;
 
 [method: UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
-public class EnumTypeParser(Type enumType, bool caseSensitive) : ICommandArgsTypeParser
+public class EnumTypeParser(Type enumType, bool caseSensitive) : ICommandTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/ArrayTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/ArrayTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class ArrayTypeParser(Type elementType, ICommandLineTypeParser itemTypeParser) : ICommandLineTypeParser
+public class ArrayTypeParser(Type elementType, ICommandArgsTypeParser itemTypeParser) : ICommandArgsTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/ArrayTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/ArrayTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class ArrayTypeParser(Type elementType, ICommandArgsTypeParser itemTypeParser) : ICommandArgsTypeParser
+public class ArrayTypeParser(Type elementType, ICommandTypeParser itemTypeParser) : ICommandTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/CollectionTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/CollectionTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class CollectionTypeParser(Type itemType) : ICommandLineTypeParser
+public class CollectionTypeParser(Type itemType) : ICommandArgsTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/CollectionTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/CollectionTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class CollectionTypeParser(Type itemType) : ICommandArgsTypeParser
+public class CollectionTypeParser(Type itemType) : ICommandTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/DictionaryTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/DictionaryTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class DictionaryTypeParser(Type itemType) : ICommandLineTypeParser
+public class DictionaryTypeParser(Type itemType) : ICommandArgsTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/DictionaryTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/DictionaryTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class DictionaryTypeParser(Type itemType) : ICommandArgsTypeParser
+public class DictionaryTypeParser(Type itemType) : ICommandTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/EnumerableTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/EnumerableTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class EnumerableTypeParser(Type itemType) : ICommandArgsTypeParser
+public class EnumerableTypeParser(Type itemType) : ICommandTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/Enumerables/EnumerableTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/Enumerables/EnumerableTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes.Enumerables;
 
-public class EnumerableTypeParser(Type itemType) : ICommandLineTypeParser
+public class EnumerableTypeParser(Type itemType) : ICommandArgsTypeParser
 {
     public Type Type => throw new NotImplementedException();
 

--- a/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class FloatTypeParser : ICommandArgsTypeParser
+public class FloatTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(float);
 

--- a/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class FloatTypeParser : ICommandLineTypeParser
+public class FloatTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(float);
 

--- a/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class IntTypeParser : ICommandArgsTypeParser
+public class IntTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(int);
 

--- a/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class IntTypeParser : ICommandLineTypeParser
+public class IntTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(int);
 

--- a/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class LongTypeParser : ICommandLineTypeParser
+public class LongTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(long);
 

--- a/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class LongTypeParser : ICommandArgsTypeParser
+public class LongTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(long);
 

--- a/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class SByteTypeParser : ICommandLineTypeParser
+public class SByteTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(sbyte);
 

--- a/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class SByteTypeParser : ICommandArgsTypeParser
+public class SByteTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(sbyte);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ShortTypeParser : ICommandLineTypeParser
+public class ShortTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(short);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ShortTypeParser : ICommandArgsTypeParser
+public class ShortTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(short);
 

--- a/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class StringTypeParser : ICommandArgsTypeParser
+public class StringTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(string);
 

--- a/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class StringTypeParser : ICommandLineTypeParser
+public class StringTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(string);
 

--- a/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class UIntTypeParser : ICommandArgsTypeParser
+public class UIntTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(uint);
 

--- a/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class UIntTypeParser : ICommandLineTypeParser
+public class UIntTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(uint);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ULongTypeParser : ICommandArgsTypeParser
+public class ULongTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(ulong);
 

--- a/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class ULongTypeParser : ICommandLineTypeParser
+public class ULongTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(ulong);
 

--- a/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class UShortTypeParser : ICommandArgsTypeParser
+public class UShortTypeParser : ICommandTypeParser
 {
     public Type Type => typeof(ushort);
 

--- a/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class UShortTypeParser : ICommandLineTypeParser
+public class UShortTypeParser : ICommandArgsTypeParser
 {
     public Type Type => typeof(ushort);
 


### PR DESCRIPTION
#### PR Classification
Refactor of the command line type parsing system.

#### PR Summary
This pull request refactors the command line type parsing system by renaming the `ICommandLineTypeParser` interface to `ICommandTypeParser` and updating all related classes and methods accordingly. 
- `ApplicationBuilder.cs`: Updated methods and properties to reference `ICommandTypeParser`.
- `ICommandTypeParser.cs`: Introduced the new interface and removed the old one.
- `AbsolutePathTypeParser.cs`, `BoolTypeParser.cs`, etc.: Updated parser classes to implement `ICommandTypeParser`.
- Documentation comments across files modified to reflect the new terminology.
