### PR TITLE
Rename AddConfiguration to AddConfigurations

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli/Presentation.cs
+++ b/ApplicationBuilderHelpers.Test.Cli/Presentation.cs
@@ -9,9 +9,9 @@ namespace ApplicationBuilderHelpers.Test.Cli;
 
 internal class Presentation : ApplicationDependency
 {
-    public override void AddConfiguration(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
+    public override void AddConfigurations(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
     {
-        base.AddConfiguration(applicationBuilder, configuration);
+        base.AddConfigurations(applicationBuilder, configuration);
 
         (configuration as ConfigurationManager)!.AddEnvironmentVariables();
     }

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -421,11 +421,11 @@ public class ApplicationBuilder
                     resolver(context);
                 }
                 var applicationBuilder = await applicationCommand.ApplicationBuilderInternal(cts.Token);
+                applicationBuilder.ApplicationDependencies.Add(applicationCommand);
                 foreach (var dependency in _applicationDependencies)
                 {
                     applicationBuilder.ApplicationDependencies.Add(dependency);
                 }
-                applicationBuilder.ApplicationDependencies.Add(applicationCommand);
                 CommandInvokerService commandInvokerService = new();
                 applicationBuilder.Services.AddSingleton(commandInvokerService);
                 applicationBuilder.Services.AddHostedService<CommandInvokerWorker>();

--- a/ApplicationBuilderHelpers/ApplicationDependency.cs
+++ b/ApplicationBuilderHelpers/ApplicationDependency.cs
@@ -20,7 +20,7 @@ public abstract class ApplicationDependency : IApplicationDependency
     }
 
     /// <inheritdoc/>
-    public virtual void AddConfiguration(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
+    public virtual void AddConfigurations(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
     {
     }
 

--- a/ApplicationBuilderHelpers/ApplicationHostBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationHostBuilder.cs
@@ -63,7 +63,7 @@ public abstract class ApplicationHostBuilder(IHostApplicationBuilder builder, Li
         }
         foreach (var applicationDependency in ApplicationDependencies)
         {
-            applicationDependency.AddConfiguration(this, Builder.Configuration);
+            applicationDependency.AddConfigurations(this, Builder.Configuration);
         }
         foreach (var applicationDependency in ApplicationDependencies)
         {

--- a/ApplicationBuilderHelpers/Interfaces/IApplicationDependency.cs
+++ b/ApplicationBuilderHelpers/Interfaces/IApplicationDependency.cs
@@ -28,10 +28,10 @@ public interface IApplicationDependency
     /// </summary>
     /// <param name="builder">The application dependency builder used to configure the application.</param>
     /// <param name="configuration">The configuration source containing settings to be added.</param>
-    void AddConfiguration(ApplicationHostBuilder applicationBuilder, IConfiguration configuration);
+    void AddConfigurations(ApplicationHostBuilder applicationBuilder, IConfiguration configuration);
 
     /// <summary>
-    /// Called after <see cref="AddConfiguration"/> to register services with the application's <see cref="IServiceCollection"/>.
+    /// Called after <see cref="AddConfigurations"/> to register services with the application's <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="builder">The application dependency builder used to configure the application.</param>
     /// <param name="services">The service collection where services are registered.</param>


### PR DESCRIPTION
#### PR Classification
Code cleanup and method renaming for consistency.

#### PR Summary
This pull request updates the method name from `AddConfiguration` to `AddConfigurations` across multiple files to enhance naming consistency and clarity in configuration handling. 
- `Presentation.cs`: Renamed method and updated base call to `AddConfigurations`.
- `ApplicationDependency.cs`: Updated method signature to `AddConfigurations`.
- `ApplicationHostBuilder.cs`: Changed method call from `AddConfiguration` to `AddConfigurations`.
- `IApplicationDependency.cs`: Updated interface method name to `AddConfigurations`.
- `ApplicationBuilder.cs`: Adjusted the order of adding `applicationCommand` to `ApplicationDependencies`.
