### PR TITLE
Handle Console.CancelKeyPress event

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -170,6 +170,7 @@ public class ApplicationBuilder
         Console.CancelKeyPress += (sender, e) =>
         {
             cancellationTokenSource.Cancel();
+            e.Cancel = false;
         };
         bool hasRootCommand = false;
         var commandLineBuilder = new CommandLineBuilder(new RootCommand())


### PR DESCRIPTION
#### PR Classification
Enhancement to console cancellation behavior.

#### PR Summary
This pull request modifies the event handler for `Console.CancelKeyPress` to allow the default console behavior to continue after a cancellation request. 
- ApplicationBuilder.cs: Added `e.Cancel = false;` to the `Console.CancelKeyPress` event handler.
