### PR TITLE
Modify Console.CancelKeyPress handling for graceful exit

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -170,7 +170,7 @@ public class ApplicationBuilder
         Console.CancelKeyPress += (sender, e) =>
         {
             cancellationTokenSource.Cancel();
-            e.Cancel = false;
+            e.Cancel = true;
         };
         bool hasRootCommand = false;
         var commandLineBuilder = new CommandLineBuilder(new RootCommand())


### PR DESCRIPTION
#### PR Classification
This pull request modifies the behavior of the application during cancellation key presses.

#### PR Summary
The changes enhance the handling of the `Console.CancelKeyPress` event to allow for a controlled shutdown of the application. 
- `ApplicationBuilder.cs`: Changed `e.Cancel` from `false` to `true` in the `Console.CancelKeyPress` event handler to prevent immediate application termination.
