### PR TITLE
Improve command line parser and add tests for negatives

### DIFF
--- a/ApplicationBuilderHelpers.Test.Cli.UnitTest/BuiltinParserTypesTests.cs
+++ b/ApplicationBuilderHelpers.Test.Cli.UnitTest/BuiltinParserTypesTests.cs
@@ -152,6 +152,15 @@ public class BuiltinParserTypesTests : CliTestBase
         CliTestAssertions.AssertOutputContains(result, $"Coverage Threshold: {expected}%");
     }
 
+    [Fact]
+    public async Task Double_Parser_Negative_Values_Without_Equals()
+    {
+        // Test negative values passed as separate arguments (the problematic case)
+        var result = await Runner.RunAsync("test", "target", "--coverage-threshold", "-1.5", "-v");
+        CliTestAssertions.AssertSuccess(result);
+        CliTestAssertions.AssertOutputContains(result, "Coverage Threshold: -1.5%");
+    }
+
     [Theory]
     [InlineData("1e2", "100")]
     [InlineData("1.5e1", "15")]


### PR DESCRIPTION
#### PR Classification
Enhancement of command line argument parsing and addition of unit tests.

#### PR Summary
This pull request introduces improvements to the command line parser's handling of numeric values and adds a new test for negative coverage thresholds. Key changes include:
- `BuiltinParserTypesTests.cs`: Added a test method `Double_Parser_Negative_Values_Without_Equals` for negative value handling.
- `CommandLineParser.cs`: Removed class name prefixes from method calls for simplification.
- `CommandLineParser.cs`: Introduced a new method `IsNumericValue` to validate numeric strings.
- `CommandLineParser.cs`: Enhanced argument parsing logic to better identify numeric options.
- `CommandLineParser.cs`: Configured `ConsoleLifetimeOptions` to suppress status messages during command execution.
