### PR TITLE
AOT friendly impl

### DIFF
--- a/ApplicationBuilderHelpers/Abstracts/CommandTypeParser.cs
+++ b/ApplicationBuilderHelpers/Abstracts/CommandTypeParser.cs
@@ -1,0 +1,55 @@
+﻿using ApplicationBuilderHelpers.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationBuilderHelpers.Abstracts;
+
+/// <summary>
+/// This is the base class for command type parsers.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public abstract class CommandTypeParser<T> : ICommandTypeParser
+{
+    public Type Type { get; } = typeof(T);
+
+    public object? Parse(string? value, out string? validateError)
+    {
+        return ParseValue(value, out validateError);
+    }
+
+    public string? GetString(object? value)
+    {
+        if (value is null)
+        {
+            return GetStringValue(default);
+        }
+        else if (value is T typedValue)
+        {
+            return GetStringValue(typedValue);
+        }
+        else
+        {
+            return value.ToString();
+        }
+    }
+
+    public object? GetDefaultValue()
+    {
+        return default(T);
+    }
+
+    public Array CreateTypedArray(int length)
+    {
+        return new T[length];
+    }
+
+    public virtual string? GetStringValue(T? value)
+    {
+        return value?.ToString();
+    }
+
+    public abstract T? ParseValue(string? value, out string? validateError);
+}

--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -124,6 +124,7 @@ public class ApplicationBuilder : ICommandBuilder
         AddCommandTypeParser<DecimalTypeParser>();
         AddCommandTypeParser<DoubleTypeParser>();
         AddCommandTypeParser<FloatTypeParser>();
+        AddCommandTypeParser<GuidTypeParser>();
         AddCommandTypeParser<IntTypeParser>();
         AddCommandTypeParser<LongTypeParser>();
         AddCommandTypeParser<SByteTypeParser>();

--- a/ApplicationBuilderHelpers/Interfaces/ICommandTypeParser.cs
+++ b/ApplicationBuilderHelpers/Interfaces/ICommandTypeParser.cs
@@ -26,4 +26,17 @@ public interface ICommandTypeParser
     /// <param name="validateError"></param>
     /// <returns></returns>
     string? GetString(object? value);
+
+    /// <summary>
+    /// Gets the default value for the type, which can be used when no value is provided.
+    /// </summary>
+    /// <returns></returns>
+    object? GetDefaultValue();
+
+    /// <summary>
+    /// Creates a typed array for AOT compatibility
+    /// </summary>
+    /// <param name="length"></param>
+    /// <returns></returns>
+    Array CreateTypedArray(int length);
 }

--- a/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/AbsolutePathTypeParser.cs
@@ -1,14 +1,13 @@
 ﻿using ApplicationBuilderHelpers.Interfaces;
 using System;
 using AbsolutePathHelpers;
+using ApplicationBuilderHelpers.Abstracts;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-public class AbsolutePathTypeParser : ICommandTypeParser
+public class AbsolutePathTypeParser : CommandTypeParser<AbsolutePath>
 {
-    public Type Type => typeof(AbsolutePath);
-
-    public object? Parse(string? value, out string? validateError)
+    public override AbsolutePath? ParseValue(string? value, out string? validateError)
     {
         if (AbsolutePath.TryParse(value, out var result))
         {
@@ -17,11 +16,6 @@ public class AbsolutePathTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/BoolTypeParser.cs
@@ -1,13 +1,13 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using AbsolutePathHelpers;
+using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class BoolTypeParser : ICommandTypeParser
+internal class BoolTypeParser : CommandTypeParser<bool>
 {
-    public Type Type => typeof(bool);
-
-    public object? Parse(string? value, out string? validateError)
+    public override bool ParseValue(string? value, out string? validateError)
     {
         if (string.IsNullOrEmpty(value)) // bool only needs a flag, not a value
         {
@@ -37,15 +37,6 @@ internal class BoolTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected 'true', 'false', 'yes', 'no', 'on', 'off', '1', or '0'";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value switch
-        {
-            bool b => b ? "true" : "false",
-            _ => null
-        };
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ByteTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class ByteTypeParser : ICommandTypeParser
+internal class ByteTypeParser : CommandTypeParser<byte>
 {
-    public Type Type => typeof(byte);
-
-    public object? Parse(string? value, out string? validateError)
+    public override byte ParseValue(string? value, out string? validateError)
     {
         if (byte.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class ByteTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/CharTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class CharTypeParser : ICommandTypeParser
+internal class CharTypeParser : CommandTypeParser<char>
 {
-    public Type Type => typeof(char);
-
-    public object? Parse(string? value, out string? validateError)
+    public override char ParseValue(string? value, out string? validateError)
     {
         if (char.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class CharTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeOffsetTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class DateTimeOffsetTypeParser : ICommandTypeParser
+internal class DateTimeOffsetTypeParser : CommandTypeParser<DateTimeOffset>
 {
-    public Type Type => typeof(DateTimeOffset);
-
-    public object? Parse(string? value, out string? validateError)
+    public override DateTimeOffset ParseValue(string? value, out string? validateError)
     {
         if (DateTimeOffset.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class DateTimeOffsetTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DateTimeTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class DateTimeTypeParser : ICommandTypeParser
+internal class DateTimeTypeParser : CommandTypeParser<DateTime>
 {
-    public Type Type => typeof(DateTime);
-
-    public object? Parse(string? value, out string? validateError)
+    public override DateTime ParseValue(string? value, out string? validateError)
     {
         if (DateTime.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class DateTimeTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DecimalTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class DecimalTypeParser : ICommandTypeParser
+internal class DecimalTypeParser : CommandTypeParser<decimal>
 {
-    public Type Type => typeof(decimal);
-
-    public object? Parse(string? value, out string? validateError)
+    public override decimal ParseValue(string? value, out string? validateError)
     {
         if (decimal.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class DecimalTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/DoubleTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class DoubleTypeParser : ICommandTypeParser
+internal class DoubleTypeParser : CommandTypeParser<double>
 {
-    public Type Type => typeof(double);
-
-    public object? Parse(string? value, out string? validateError)
+    public override double ParseValue(string? value, out string? validateError)
     {
         if (double.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class DoubleTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/FloatTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class FloatTypeParser : ICommandTypeParser
+internal class FloatTypeParser : CommandTypeParser<float>
 {
-    public Type Type => typeof(float);
-
-    public object? Parse(string? value, out string? validateError)
+    public override float ParseValue(string? value, out string? validateError)
     {
         if (float.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class FloatTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/GuidTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/GuidTypeParser.cs
@@ -1,0 +1,21 @@
+﻿using AbsolutePathHelpers;
+using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
+using System;
+
+namespace ApplicationBuilderHelpers.ParserTypes;
+
+internal class GuidTypeParser : CommandTypeParser<Guid>
+{
+    public override Guid ParseValue(string? value, out string? validateError)
+    {
+        if (Guid.TryParse(value, out var result))
+        {
+            validateError = null;
+            return result;
+        }
+
+        validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
+        return default;
+    }
+}

--- a/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/IntTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class IntTypeParser : ICommandTypeParser
+internal class IntTypeParser : CommandTypeParser<int>
 {
-    public Type Type => typeof(int);
-
-    public object? Parse(string? value, out string? validateError)
+    public override int ParseValue(string? value, out string? validateError)
     {
         if (int.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class IntTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/LongTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class LongTypeParser : ICommandTypeParser
+internal class LongTypeParser : CommandTypeParser<long>
 {
-    public Type Type => typeof(long);
-
-    public object? Parse(string? value, out string? validateError)
+    public override long ParseValue(string? value, out string? validateError)
     {
         if (long.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class LongTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/SByteTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class SByteTypeParser : ICommandTypeParser
+internal class SByteTypeParser : CommandTypeParser<sbyte>
 {
-    public Type Type => typeof(sbyte);
-
-    public object? Parse(string? value, out string? validateError)
+    public override sbyte ParseValue(string? value, out string? validateError)
     {
         if (sbyte.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class SByteTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ShortTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class ShortTypeParser : ICommandTypeParser
+internal class ShortTypeParser : CommandTypeParser<short>
 {
-    public Type Type => typeof(short);
-
-    public object? Parse(string? value, out string? validateError)
+    public override short ParseValue(string? value, out string? validateError)
     {
         if (short.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class ShortTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/StringTypeParser.cs
@@ -1,20 +1,14 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class StringTypeParser : ICommandTypeParser
+internal class StringTypeParser : CommandTypeParser<string>
 {
-    public Type Type => typeof(string);
-
-    public object? Parse(string? value, out string? validateError)
+    public override string? ParseValue(string? value, out string? validateError)
     {
         validateError = null;
         return value;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UIntTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class UIntTypeParser : ICommandTypeParser
+internal class UIntTypeParser : CommandTypeParser<uint>
 {
-    public Type Type => typeof(uint);
-
-    public object? Parse(string? value, out string? validateError)
+    public override uint ParseValue(string? value, out string? validateError)
     {
         if (uint.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class UIntTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/ULongTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class ULongTypeParser : ICommandTypeParser
+internal class ULongTypeParser : CommandTypeParser<ulong>
 {
-    public Type Type => typeof(ulong);
-
-    public object? Parse(string? value, out string? validateError)
+    public override ulong ParseValue(string? value, out string? validateError)
     {
         if (ulong.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class ULongTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }

--- a/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
+++ b/ApplicationBuilderHelpers/ParserTypes/UShortTypeParser.cs
@@ -1,13 +1,12 @@
-﻿using ApplicationBuilderHelpers.Interfaces;
+﻿using ApplicationBuilderHelpers.Abstracts;
+using ApplicationBuilderHelpers.Interfaces;
 using System;
 
 namespace ApplicationBuilderHelpers.ParserTypes;
 
-internal class UShortTypeParser : ICommandTypeParser
+internal class UShortTypeParser : CommandTypeParser<ushort>
 {
-    public Type Type => typeof(ushort);
-
-    public object? Parse(string? value, out string? validateError)
+    public override ushort ParseValue(string? value, out string? validateError)
     {
         if (ushort.TryParse(value, out var result))
         {
@@ -16,11 +15,6 @@ internal class UShortTypeParser : ICommandTypeParser
         }
 
         validateError = $"Invalid {Type.Name} value: '{value}'. Expected a valid {Type.Name}.";
-        return null;
-    }
-
-    public string? GetString(object? value)
-    {
-        return value?.ToString();
+        return default;
     }
 }


### PR DESCRIPTION
#### PR Classification
New feature and design improvement.

#### PR Summary
This pull request introduces the `CommandTypeParser<T>` abstract class for command type parsing, enhancing AOT compatibility and refactoring existing type parsers to inherit from it. Key changes include:
- **CommandTypeParser.cs**: Added `CommandTypeParser<T>` class with methods for parsing, string conversion, and typed array creation.
- **ApplicationBuilder.cs**: Updated to include `GuidTypeParser` for expanded type support.
- **CommandLineParser.cs**: Modified methods to include `DynamicallyAccessedMembers` attribute and added manual extraction methods for options and arguments.
- **ICommandTypeParser.cs**: Updated interface to include methods for default values and typed array creation.
- **Type Parser Classes**: Refactored multiple type parsers (e.g., `AbsolutePathTypeParser`, `BoolTypeParser`) to inherit from `CommandTypeParser<T>`.
