### PR TITLE
Refactor command handling with TypedCommandHolder

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilder.cs
+++ b/ApplicationBuilderHelpers/ApplicationBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using ApplicationBuilderHelpers.Extensions;
 using ApplicationBuilderHelpers.Interfaces;
+using ApplicationBuilderHelpers.Models;
 using ApplicationBuilderHelpers.ParserTypes;
 using ApplicationBuilderHelpers.Themes;
 using System;
@@ -22,7 +23,7 @@ public class ApplicationBuilder : ICommandBuilder
     int? ICommandBuilder.HelpWidth { get; set; } = null;
     int? ICommandBuilder.HelpBorderWidth { get; set; } = null;
     IConsoleTheme? ICommandBuilder.Theme { get; set; } = DefaultConsoleTheme.Instance;
-    List<ICommand> ICommandBuilder.Commands { get; } = [];
+    List<TypedCommandHolder> ICommandBuilder.Commands { get; } = [];
     List<IApplicationDependency> IApplicationDependencyCollection.ApplicationDependencies { get; } = [];
     Dictionary<Type, ICommandTypeParser> ICommandTypeParserCollection.TypeParsers { get; } = [];
 
@@ -50,7 +51,7 @@ public class ApplicationBuilder : ICommandBuilder
     /// </summary>
     /// <typeparam name="TCommand">The type of command that implements <see cref="ICommand"/>.</typeparam>
     /// <returns>The current <see cref="ApplicationBuilder"/> instance for method chaining.</returns>
-    public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommand>()
+    public ApplicationBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>()
         where TCommand : ICommand
         => ICommandBuilderExtensions.AddCommand<TCommand, ApplicationBuilder>(this);
 

--- a/ApplicationBuilderHelpers/Extensions/ICommandBuilderExtensions.cs
+++ b/ApplicationBuilderHelpers/Extensions/ICommandBuilderExtensions.cs
@@ -176,7 +176,7 @@ public static class ICommandBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(commandBuilder);
         ArgumentNullException.ThrowIfNull(command);
-        commandBuilder.Commands.Add(command);
+        commandBuilder.Commands.Add(new Models.TypedCommandHolder(command.GetType(), command));
         return commandBuilder;
     }
 
@@ -188,14 +188,14 @@ public static class ICommandBuilderExtensions
     /// <param name="commandBuilder">The command builder instance.</param>
     /// <returns>The command builder instance for method chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="commandBuilder"/> is null.</exception>
-    public static TICommandBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TCommand, TICommandBuilder>(this TICommandBuilder commandBuilder)
+    public static TICommandBuilder AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand, TICommandBuilder>(this TICommandBuilder commandBuilder)
         where TCommand : ICommand
         where TICommandBuilder : ICommandBuilder
     {
         ArgumentNullException.ThrowIfNull(commandBuilder);
         var command = Activator.CreateInstance<TCommand>();
         ArgumentNullException.ThrowIfNull(command);
-        commandBuilder.Commands.Add(command);
+        commandBuilder.Commands.Add(new Models.TypedCommandHolder(typeof(TCommand), command));
         return commandBuilder;
     }
 }

--- a/ApplicationBuilderHelpers/Interfaces/ICommandBuilder.cs
+++ b/ApplicationBuilderHelpers/Interfaces/ICommandBuilder.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using ApplicationBuilderHelpers.Models;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ApplicationBuilderHelpers.Interfaces;
@@ -9,7 +11,7 @@ namespace ApplicationBuilderHelpers.Interfaces;
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
 public interface ICommandBuilder : ICommandTypeParserCollection, IApplicationDependencyCollection
 {
-    internal List<ICommand> Commands { get; }
+    internal List<TypedCommandHolder> Commands { get; }
 
     internal string? ExecutableName { get; set; }
 

--- a/ApplicationBuilderHelpers/Models/TypedCommandHolder.cs
+++ b/ApplicationBuilderHelpers/Models/TypedCommandHolder.cs
@@ -1,0 +1,17 @@
+﻿using ApplicationBuilderHelpers.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationBuilderHelpers.Models;
+
+internal class TypedCommandHolder([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type commandType, ICommand command)
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public Type CommandType { get; init; } = commandType ?? throw new ArgumentNullException(nameof(commandType));
+
+    public ICommand Command { get; init; } = command ?? throw new ArgumentNullException(nameof(command));
+}


### PR DESCRIPTION
#### PR Classification
Refactor to improve command handling structure.

#### PR Summary
This pull request refactors the command handling system by introducing a `TypedCommandHolder` class to encapsulate commands and their types, enhancing type safety and organization. 
- **ApplicationBuilder.cs**: Changed `ICommandBuilder.Commands` from `List<ICommand>` to `List<TypedCommandHolder>` and updated the `AddCommand` method's generic constraints.
- **CommandLineParser.cs**: Updated to iterate over `TypedCommandHolder` instances and modified methods for extracting options and arguments accordingly.
- **ICommandBuilderExtensions.cs**: Modified `AddCommand` methods to add `TypedCommandHolder` instances instead of `ICommand`.
- **ICommandBuilder.cs**: Updated `Commands` property type to `List<TypedCommandHolder>`.
- **TypedCommandHolder.cs**: Introduced a new class to hold command instances along with their types.
