### PR TITLE
Update AbsolutePathHelpers package version

### DIFF
--- a/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
+++ b/ApplicationBuilderHelpers/ApplicationBuilderHelpers.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AbsolutePathHelpers" Version="0.3.10" />
+		<PackageReference Include="AbsolutePathHelpers" Version="0.3.12" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
 	</ItemGroup>


### PR DESCRIPTION
Update AbsolutePathHelpers package version

Updated the `AbsolutePathHelpers` package from version
`0.3.10` to `0.3.12` in the `ApplicationBuilderHelpers.csproj` file.