### PR TITLE
fix: update Nuke build paths after src/ restructure

### DIFF
--- a/.github/workflows/nuke-cicd.yml
+++ b/.github/workflows/nuke-cicd.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on:
       labels: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -64,14 +64,14 @@ jobs:
     name: Test - application_builder_helpers (ApplicationBuilderHelpersTest)
     runs-on: ${{ fromJson(needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_RUNS_ON) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_CHECKOUT_FETCH_DEPTH }}
         fetch-tags: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_CHECKOUT_FETCH_TAGS }}
         submodules: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_CHECKOUT_SUBMODULES }}
         persist-credentials: true
     - name: Cache Run
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./.nuke/temp/cache
         key: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_CACHE_KEY }}
@@ -82,14 +82,14 @@ jobs:
       name: Run Nuke ApplicationBuilderHelpersTest
       run: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSTEST_RUN_SCRIPT }} Run --args "ApplicationBuilderHelpersTest"
     - name: Upload application_builder_helpers pre_test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pre_test___application_builder_helpers___APPLICATIONBUILDERHELPERSTEST
         path: ./.nuke/temp/artifacts-upload/application_builder_helpers/*
         if-no-files-found: error
         retention-days: 1
     - name: Upload common pre_test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pre_test___$common___APPLICATIONBUILDERHELPERSTEST
         path: ./.nuke/temp/artifacts-upload/$common/*
@@ -104,19 +104,19 @@ jobs:
     name: Build - application_builder_helpers (ApplicationBuilderHelpersBuild)
     runs-on: ${{ fromJson(needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_RUNS_ON) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_CHECKOUT_FETCH_DEPTH }}
         fetch-tags: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_CHECKOUT_FETCH_TAGS }}
         submodules: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_CHECKOUT_SUBMODULES }}
         persist-credentials: true
     - name: Download application_builder_helpers pre_test artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: ./.nuke/temp/artifacts-download
         pattern: pre_test___application_builder_helpers___*
     - name: Cache Run
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./.nuke/temp/cache
         key: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_CACHE_KEY }}
@@ -127,14 +127,14 @@ jobs:
       name: Run Nuke ApplicationBuilderHelpersBuild
       run: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSBUILD_RUN_SCRIPT }} Run --args "ApplicationBuilderHelpersBuild"
     - name: Upload application_builder_helpers build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build___application_builder_helpers___APPLICATIONBUILDERHELPERSBUILD
         path: ./.nuke/temp/artifacts-upload/application_builder_helpers/*
         if-no-files-found: error
         retention-days: 1
     - name: Upload common build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build___$common___APPLICATIONBUILDERHELPERSBUILD
         path: ./.nuke/temp/artifacts-upload/$common/*
@@ -150,29 +150,29 @@ jobs:
     name: Publish - application_builder_helpers (ApplicationBuilderHelpersPublish)
     runs-on: ${{ fromJson(needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_RUNS_ON) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_CHECKOUT_FETCH_DEPTH }}
         fetch-tags: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_CHECKOUT_FETCH_TAGS }}
         submodules: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_CHECKOUT_SUBMODULES }}
         persist-credentials: true
     - name: Download application_builder_helpers pre_test artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: ./.nuke/temp/artifacts-download
         pattern: pre_test___application_builder_helpers___*
     - name: Download application_builder_helpers build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: ./.nuke/temp/artifacts-download
         pattern: build___application_builder_helpers___*
     - name: Download application_builder_helpers post_test artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: ./.nuke/temp/artifacts-download
         pattern: post_test___application_builder_helpers___*
     - name: Cache Run
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./.nuke/temp/cache
         key: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_CACHE_KEY }}
@@ -183,7 +183,7 @@ jobs:
       name: Run Nuke ApplicationBuilderHelpersPublish
       run: ${{ needs.PRE_SETUP.outputs.NUKE_PRE_SETUP_APPLICATIONBUILDERHELPERSPUBLISH_RUN_SCRIPT }} Run --args "ApplicationBuilderHelpersPublish"
     - name: Upload common publish artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: publish___$common___APPLICATIONBUILDERHELPERSPUBLISH
         path: ./.nuke/temp/artifacts-upload/$common/*
@@ -201,14 +201,14 @@ jobs:
     runs-on:
       labels: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
         submodules: recursive
         persist-credentials: true
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: ./.nuke/temp/artifacts-download
         pattern: '*___*'

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -64,12 +64,12 @@ class Build : BaseNukeBuildHelpers
             }
             app.OutputDirectory.DeleteDirectory();
             DotNetTasks.DotNetClean(_ => _
-                .SetProject(RootDirectory / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj"));
+                .SetProject(RootDirectory / "src" / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj"));
             DotNetTasks.DotNetBuild(_ => _
-                .SetProjectFile(RootDirectory / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj")
+                .SetProjectFile(RootDirectory / "src" / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj")
                 .SetConfiguration("Release"));
             DotNetTasks.DotNetPack(_ => _
-                .SetProject(RootDirectory / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj")
+                .SetProject(RootDirectory / "src" / "ApplicationBuilderHelpers" / "ApplicationBuilderHelpers.csproj")
                 .SetConfiguration("Release")
                 .SetNoRestore(true)
                 .SetNoBuild(true)


### PR DESCRIPTION
## Problem
The `ApplicationBuilderHelpersBuild` stage in CI/CD was failing with:
```
MSBUILD : error MSB1009: Project file does not exist.
```

## Cause
When the projects were moved from root into `src/` (commit e080790), the `ApplicationBuilderHelpersTest` Nuke entry paths were updated but the `ApplicationBuilderHelpersBuild` entry paths were missed.

## Fix
Updated the `Build` entry in `build/Build.cs` to use `"src" / "ApplicationBuilderHelpers" /` instead of `"ApplicationBuilderHelpers" /` for:
- `DotNetClean`
- `DotNetBuild`
- `DotNetPack`

## Verification
- `dotnet build build/_build.csproj` — passes
- `dotnet build ApplicationBuilderHelpers.slnx` — passes with NuGet pack
- `./build.sh PipelinePreSetup` — runs successfully
- CI Test stage was already passing; Build stage will now pass