### PR TITLE
deps: update all NuGet packages across entire repo

### DIFF
--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Application/Application.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Application/Application.csproj
@@ -11,10 +11,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
 		<PackageReference Include="CliWrap" Version="3.10.0" />
 		<PackageReference Include="Semver" Version="3.0.0" />
 	</ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Domain/Domain.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Domain/Domain.csproj
@@ -15,9 +15,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.0" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
 		<PackageReference Include="DisposableHelpers" Version="1.2.152" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore.Identity/Infrastructure.EFCore.Identity.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore.Identity/Infrastructure.EFCore.Identity.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore.Sqlite/Infrastructure.EFCore.Sqlite.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore.Sqlite/Infrastructure.EFCore.Sqlite.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore/Infrastructure.EFCore.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.EFCore/Infrastructure.EFCore.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.OpenTelemetry/Infrastructure.OpenTelemetry.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Infrastructure.OpenTelemetry/Infrastructure.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.9" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Presentation.WebApi/Presentation.WebApi.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Presentation.WebApi/Presentation.WebApi.csproj
@@ -23,9 +23,9 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Presentation/Presentation.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/src/Presentation/Presentation.csproj
@@ -10,9 +10,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -11,10 +11,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -9,8 +9,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Presentation.WebApi.FunctionalTests/Presentation.WebApi.FunctionalTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApi/tests/Presentation.WebApi.FunctionalTests/Presentation.WebApi.FunctionalTests.csproj
@@ -12,9 +12,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Application.Client/Application.Client.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Application.Client/Application.Client.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Application/Application.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Application/Application.csproj
@@ -12,9 +12,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
 		<PackageReference Include="CliWrap" Version="3.10.0" />
 	</ItemGroup>
 

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Domain/Domain.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Domain/Domain.csproj
@@ -15,9 +15,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.0" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
 		<PackageReference Include="DisposableHelpers" Version="1.2.152" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 </Project>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.Browser.IndexedDB.LocalStore/Infrastructure.Browser.IndexedDB.LocalStore.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.Browser.IndexedDB.LocalStore/Infrastructure.Browser.IndexedDB.LocalStore.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore.Server.Identity/Infrastructure.EFCore.Server.Identity.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore.Server.Identity/Infrastructure.EFCore.Server.Identity.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
 	</ItemGroup>
 

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore.Sqlite/Infrastructure.EFCore.Sqlite.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore.Sqlite/Infrastructure.EFCore.Sqlite.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore/Infrastructure.EFCore.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.EFCore/Infrastructure.EFCore.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.OpenTelemetry/Infrastructure.OpenTelemetry.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.OpenTelemetry/Infrastructure.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.9" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.Server.Identity/Infrastructure.Server.Identity.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Infrastructure.Server.Identity/Infrastructure.Server.Identity.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp.Client/Presentation.WebApp.Client.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp.Client/Presentation.WebApp.Client.csproj
@@ -24,9 +24,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp.Server/Presentation.WebApp.Server.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp.Server/Presentation.WebApp.Server.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.12.6" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp/Presentation.WebApp.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation.WebApp/Presentation.WebApp.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation/Presentation.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/src/Presentation/Presentation.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -15,10 +15,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -13,9 +13,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -13,8 +13,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Presentation.WebApp.Client.FunctionalTests/Presentation.WebApp.Client.FunctionalTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Presentation.WebApp.Client.FunctionalTests/Presentation.WebApp.Client.FunctionalTests.csproj
@@ -21,8 +21,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Presentation.WebApp.Server.FunctionalTests/Presentation.WebApp.Server.FunctionalTests.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate.WebApiAndWebApp/tests/Presentation.WebApp.Server.FunctionalTests/Presentation.WebApp.Server.FunctionalTests.csproj
@@ -16,9 +16,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="coverlet.collector" Version="10.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/templates/ApplicationBuilderHelpersTemplate/src/Application/Application.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate/src/Application/Application.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/ApplicationBuilderHelpersTemplate/src/Domain/Domain.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.86" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 

--- a/templates/ApplicationBuilderHelpersTemplate/src/Presentation/Presentation.csproj
+++ b/templates/ApplicationBuilderHelpersTemplate/src/Presentation/Presentation.csproj
@@ -6,9 +6,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.86" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.87" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

Update all NuGet packages to latest versions across the entire repository.

### Main solution
| Package | From | To |
|---|---|---|
| Microsoft.Extensions.Hosting | 10.0.0 | 10.0.9 |

### Templates (34 csproj files)
| Package pattern | From | To |
|---|---|---|
| Microsoft.Extensions.\* / Microsoft.AspNetCore.\* / EF Core | 10.0.2 | 10.0.9 |
| ApplicationBuilderHelpers | 4.1.86 / 4.1.0 | 4.1.87 |
| coverlet.collector | 6.0.4 | 10.0.1 |
| Microsoft.NET.Test.Sdk | 18.0.1 | 18.6.0 |
| GitHubActionsTestLogger | 3.0.3 | 3.0.4 |

### Verification
- `dotnet build ApplicationBuilderHelpers.slnx` ✅ passes with NuGet pack
- `dotnet restore` on ApplicationBuilderHelpersTemplate.slnx ✅
- `dotnet restore` on ApplicationBuilderHelpersTemplate.WebApi.sln ✅